### PR TITLE
refactor: remove panic from validate

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,13 +5,11 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/invopop/jsonschema"
@@ -277,23 +275,4 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
-
-	t.Run("schema generation error", func(t *testing.T) {
-		t.Cleanup(func() {
-			_schema = ""
-			_schemaOnce = sync.Once{}
-			_schemaOnceErr = nil
-		})
-
-		errMsg := "schema generation error"
-
-		_schemaOnceErr = errors.New(errMsg)
-
-		for range 3 {
-			err := Validate(nil)
-
-			require.Error(t, err)
-			assert.EqualError(t, _schemaOnceErr, errMsg)
-		}
-	})
 }


### PR DESCRIPTION
Previously `Validate` could panic if JSON marshalling of the schema failed. Refactored to use `sync.OnceValues` vs `sync.Once` to avoid panic as a valid control flow.