### PR TITLE
refactor: move meta schema gen to lib

### DIFF
--- a/cmd/maru2-schema/main.go
+++ b/cmd/maru2-schema/main.go
@@ -9,41 +9,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/invopop/jsonschema"
-
-	v0 "github.com/defenseunicorns/maru2/schema/v0"
+	"github.com/defenseunicorns/maru2"
 )
 
 func main() {
-	var schema *jsonschema.Schema
-
 	version := ""
 	if len(os.Args) > 1 {
 		version = os.Args[1]
 	}
 
-	switch version {
-	case v0.SchemaVersion:
-		schema = v0.WorkFlowSchema()
-	default:
-		schema = &jsonschema.Schema{
-			If: &jsonschema.Schema{
-				Properties: jsonschema.NewProperties(),
-			},
-			Then: &jsonschema.Schema{
-				Properties: jsonschema.NewProperties(),
-			},
-			ID:      "https://raw.githubusercontent.com/defenseunicorns/maru2/main/maru2.schema.json",
-			Version: jsonschema.Version,
-		}
-
-		schema.If.Properties.Set("schema-version", &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{v0.SchemaVersion},
-		})
-
-		schema.Then = v0.WorkFlowSchema()
-	}
+	schema := maru2.WorkflowSchema(version)
 
 	b, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-Present Defense Unicorns
+
+package maru2
+
+import (
+	v0 "github.com/defenseunicorns/maru2/schema/v0"
+	"github.com/invopop/jsonschema"
+)
+
+// WorkflowSchema generates the schema for either a given version, or all versions in one meta schema
+func WorkflowSchema(version string) *jsonschema.Schema {
+	var schema *jsonschema.Schema
+
+	switch version {
+	case v0.SchemaVersion:
+		schema = v0.WorkFlowSchema()
+	default:
+		schema = &jsonschema.Schema{
+			If: &jsonschema.Schema{
+				Properties: jsonschema.NewProperties(),
+			},
+			Then: &jsonschema.Schema{
+				Properties: jsonschema.NewProperties(),
+			},
+			ID:      "https://raw.githubusercontent.com/defenseunicorns/maru2/main/maru2.schema.json",
+			Version: jsonschema.Version,
+		}
+
+		schema.If.Properties.Set("schema-version", &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{v0.SchemaVersion},
+		})
+
+		schema.Then = v0.WorkFlowSchema()
+	}
+
+	return schema
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-Present Defense Unicorns
+
+package maru2
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	v0 "github.com/defenseunicorns/maru2/schema/v0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowSchema(t *testing.T) {
+	t.Run(v0.SchemaVersion, func(t *testing.T) {
+		schema := WorkflowSchema(v0.SchemaVersion)
+		b, err := json.Marshal(schema)
+		require.NoError(t, err)
+
+		current, err := os.ReadFile("schema/v0/schema.json")
+		require.NoError(t, err)
+
+		assert.JSONEq(t, string(current), string(b))
+	})
+	t.Run("meta", func(t *testing.T) {
+		schema := WorkflowSchema("")
+		b, err := json.Marshal(schema)
+		require.NoError(t, err)
+
+		current, err := os.ReadFile("maru2.schema.json")
+		require.NoError(t, err)
+
+		assert.JSONEq(t, string(current), string(b))
+	})
+}


### PR DESCRIPTION
Move schema gen out of `cmd/maru2-schema/main.go` and into an SDK function.
