### PR TITLE
refactor: allow default and default-from-env

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -545,17 +545,27 @@ echo "Hello, Jeff"
 Hello, Jeff
 ```
 
-If the specified environment variable is not set, an error will be returned:
+### Priority Order for Default Values
 
-```sh
-# With NON_EXISTENT_ENV_VAR not set
-maru2 hello
+You can specify both `default` and `default-from-env` for the same input parameter. Maru2 uses the following priority order:
 
-ERRO environment variable "NON_EXISTENT_ENV_VAR" not set and no input provided for "name"
-ERRO at (file:tasks.yaml)
+1. **Provided input** (via `--with` flag or `with:` property) - highest priority
+2. **Environment variable** (via `default-from-env`) - if the environment variable exists
+3. **Static default** (via `default`) - fallback if environment variable doesn't exist
+4. **No value** - if none of the above are available and the input is required, an error occurs
+
+```yaml
+schema-version: v0
+inputs:
+  ci:
+    description: "Am I running in CI?"
+    default-from-env: CI
+    default: false
+
+tasks:
+  hello:
+    - run: echo "CI is ${{ input "ci" }}"
 ```
-
-Note that `default` and `default-from-env` are mutually exclusive - you can only specify one of them for a given input parameter.
 
 ## Input validation
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -214,7 +214,7 @@ Input parameters have the following properties:
 - `validate`: A regular expression to validate the parameter value
 - `deprecated-message`: A warning message to display when the parameter is used (for deprecated parameters)
 
-Note that `default` and `default-from-env` are mutually exclusive - you can only specify one of them for a given input parameter.
+See [priority order for default values](#priority-order-for-default-values).
 
 ## Passing inputs
 

--- a/maru2.schema.json
+++ b/maru2.schema.json
@@ -25,44 +25,6 @@
       },
       "inputs": {
         "additionalProperties": {
-          "oneOf": [
-            {
-              "not": {
-                "required": [
-                  "default-from-env"
-                ]
-              },
-              "required": [
-                "default"
-              ]
-            },
-            {
-              "not": {
-                "required": [
-                  "default"
-                ]
-              },
-              "required": [
-                "default-from-env"
-              ]
-            },
-            {
-              "not": {
-                "anyOf": [
-                  {
-                    "required": [
-                      "default"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "default-from-env"
-                    ]
-                  }
-                ]
-              }
-            }
-          ],
           "properties": {
             "description": {
               "type": "string",
@@ -106,10 +68,6 @@
           "required": [
             "description"
           ],
-          "dependentRequired": {
-            "default": [],
-            "default-from-env": []
-          },
           "description": "Input parameter for the workflow"
         },
         "propertyNames": {

--- a/schema/v0/input.go
+++ b/schema/v0/input.go
@@ -35,29 +35,6 @@ type InputParameter struct {
 func (InputParameter) JSONSchemaExtend(schema *jsonschema.Schema) {
 	schema.Description = "Input parameter for the workflow"
 
-	defaultSchema := &jsonschema.Schema{
-		Description: "Default value for the parameter, can be a string or a primitive type",
-		OneOf: []*jsonschema.Schema{
-			{
-				Type: "string",
-			},
-			{
-				Type: "boolean",
-			},
-			{
-				Type: "integer",
-			},
-		},
-	}
-
-	defaultFromEnvSchema := &jsonschema.Schema{
-		Type: "string",
-		Description: `Environment variable to use as default value for the parameter
-
-See https://github.com/defenseunicorns/maru2/blob/main/docs/syntax.md#default-values-from-environment-variables`,
-		Pattern: EnvVariablePattern.String(),
-	}
-
 	schema.Properties.Set("description", &jsonschema.Schema{
 		Type:        "string",
 		Description: "Description of the parameter",
@@ -81,39 +58,25 @@ See https://github.com/defenseunicorns/maru2/blob/main/docs/syntax.md#default-va
 See https://github.com/defenseunicorns/maru2/blob/main/docs/syntax.md#input-validation`,
 	})
 
-	schema.Properties.Set("default", defaultSchema)
-	schema.Properties.Set("default-from-env", defaultFromEnvSchema)
+	schema.Properties.Set("default", &jsonschema.Schema{
+		Description: "Default value for the parameter, can be a string or a primitive type",
+		OneOf: []*jsonschema.Schema{
+			{
+				Type: "string",
+			},
+			{
+				Type: "boolean",
+			},
+			{
+				Type: "integer",
+			},
+		},
+	})
+	schema.Properties.Set("default-from-env", &jsonschema.Schema{
+		Type: "string",
+		Description: `Environment variable to use as default value for the parameter
 
-	// Add a constraint to ensure they are mutually exclusive
-	// schema.DependentRequired = map[string][]string{
-	// 	"default":          {},
-	// 	"default-from-env": {},
-	// }
-
-	// schema.OneOf = []*jsonschema.Schema{
-	// 	{
-	// 		Required: []string{"default"},
-	// 		Not: &jsonschema.Schema{
-	// 			Required: []string{"default-from-env"},
-	// 		},
-	// 	},
-	// 	{
-	// 		Required: []string{"default-from-env"},
-	// 		Not: &jsonschema.Schema{
-	// 			Required: []string{"default"},
-	// 		},
-	// 	},
-	// 	{
-	// 		Not: &jsonschema.Schema{
-	// 			AnyOf: []*jsonschema.Schema{
-	// 				{
-	// 					Required: []string{"default"},
-	// 				},
-	// 				{
-	// 					Required: []string{"default-from-env"},
-	// 				},
-	// 			},
-	// 		},
-	// 	},
-	// }
+See https://github.com/defenseunicorns/maru2/blob/main/docs/syntax.md#default-values-from-environment-variables`,
+		Pattern: EnvVariablePattern.String(),
+	})
 }

--- a/schema/v0/input.go
+++ b/schema/v0/input.go
@@ -85,35 +85,35 @@ See https://github.com/defenseunicorns/maru2/blob/main/docs/syntax.md#input-vali
 	schema.Properties.Set("default-from-env", defaultFromEnvSchema)
 
 	// Add a constraint to ensure they are mutually exclusive
-	schema.DependentRequired = map[string][]string{
-		"default":          {},
-		"default-from-env": {},
-	}
+	// schema.DependentRequired = map[string][]string{
+	// 	"default":          {},
+	// 	"default-from-env": {},
+	// }
 
-	schema.OneOf = []*jsonschema.Schema{
-		{
-			Required: []string{"default"},
-			Not: &jsonschema.Schema{
-				Required: []string{"default-from-env"},
-			},
-		},
-		{
-			Required: []string{"default-from-env"},
-			Not: &jsonschema.Schema{
-				Required: []string{"default"},
-			},
-		},
-		{
-			Not: &jsonschema.Schema{
-				AnyOf: []*jsonschema.Schema{
-					{
-						Required: []string{"default"},
-					},
-					{
-						Required: []string{"default-from-env"},
-					},
-				},
-			},
-		},
-	}
+	// schema.OneOf = []*jsonschema.Schema{
+	// 	{
+	// 		Required: []string{"default"},
+	// 		Not: &jsonschema.Schema{
+	// 			Required: []string{"default-from-env"},
+	// 		},
+	// 	},
+	// 	{
+	// 		Required: []string{"default-from-env"},
+	// 		Not: &jsonschema.Schema{
+	// 			Required: []string{"default"},
+	// 		},
+	// 	},
+	// 	{
+	// 		Not: &jsonschema.Schema{
+	// 			AnyOf: []*jsonschema.Schema{
+	// 				{
+	// 					Required: []string{"default"},
+	// 				},
+	// 				{
+	// 					Required: []string{"default-from-env"},
+	// 				},
+	// 			},
+	// 		},
+	// 	},
+	// }
 }

--- a/schema/v0/schema.json
+++ b/schema/v0/schema.json
@@ -12,44 +12,6 @@
     },
     "inputs": {
       "additionalProperties": {
-        "oneOf": [
-          {
-            "not": {
-              "required": [
-                "default-from-env"
-              ]
-            },
-            "required": [
-              "default"
-            ]
-          },
-          {
-            "not": {
-              "required": [
-                "default"
-              ]
-            },
-            "required": [
-              "default-from-env"
-            ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "default"
-                  ]
-                },
-                {
-                  "required": [
-                    "default-from-env"
-                  ]
-                }
-              ]
-            }
-          }
-        ],
         "properties": {
           "description": {
             "type": "string",
@@ -93,10 +55,6 @@
         "required": [
           "description"
         ],
-        "dependentRequired": {
-          "default": [],
-          "default-from-env": []
-        },
         "description": "Input parameter for the workflow"
       },
       "propertyNames": {

--- a/testdata/hello.yaml
+++ b/testdata/hello.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../schema/v0/schema.json
+schema-version: v0
+inputs:
+  ci:
+    description: Am I running in CI?
+    default-from-env: CI
+    default: false
+
+tasks:
+  foo:
+    - run: echo "I'm running in CI"
+      if: input("ci") == true
+    - run: echo "CI is ${{ input "ci" }}"

--- a/with.go
+++ b/with.go
@@ -216,17 +216,13 @@ func MergeWithAndParams(ctx context.Context, with v0.With, params v0.InputMap) (
 			if merged == nil {
 				merged = make(v0.With)
 			}
-			// param.Default and param.DefaultFromEnv are mutually exclusive
-			// enforced by JSON schema
+			if merged[name] == nil && param.DefaultFromEnv != "" {
+				if val, ok := os.LookupEnv(param.DefaultFromEnv); ok {
+					merged[name] = val
+				}
+			}
 			if merged[name] == nil && param.Default != nil {
 				merged[name] = param.Default
-			}
-			if merged[name] == nil && param.DefaultFromEnv != "" {
-				val, ok := os.LookupEnv(param.DefaultFromEnv)
-				if !ok {
-					return nil, fmt.Errorf("environment variable %q not set and no input provided for %q", param.DefaultFromEnv, name)
-				}
-				merged[name] = val
 			}
 		}
 		// If the input is deprecated AND provided, log a warning

--- a/with.go
+++ b/with.go
@@ -209,6 +209,7 @@ func MergeWithAndParams(ctx context.Context, with v0.With, params v0.InputMap) (
 		// the default behavior is that an input is required, this is reflected in the json schema "default" value field
 		required := param.Required == nil || (param.Required != nil && *param.Required)
 
+		// provided > default from env > default > dne
 		if _, ok := merged[name]; !ok {
 			if required && merged[name] == nil && param.Default == nil && param.DefaultFromEnv == "" {
 				return nil, fmt.Errorf("missing required input: %q", name)

--- a/with_test.go
+++ b/with_test.go
@@ -675,7 +675,7 @@ func TestMergeWithAndParams(t *testing.T) {
 					DefaultFromEnv: "NON_EXISTENT_ENV_VAR",
 				},
 			},
-			expectedError: "environment variable \"NON_EXISTENT_ENV_VAR\" not set and no input provided for \"missing\"",
+			expected: v0.With{},
 		},
 		{
 			name: "with provided value overriding default-from-env",
@@ -719,7 +719,7 @@ func TestMergeWithAndParams(t *testing.T) {
 			expectedError: "failed to validate: input=name, value=env-value, regexp=^invalid",
 		},
 		{
-			name: "test mutual exclusivity between default and default-from-env",
+			name: "test priority order: default-from-env over default",
 			with: v0.With{},
 			params: v0.InputMap{
 				"name": v0.InputParameter{
@@ -729,7 +729,21 @@ func TestMergeWithAndParams(t *testing.T) {
 				},
 			},
 			expected: v0.With{
-				"name": "default-value",
+				"name": "env-value",
+			},
+		},
+		{
+			name: "test fallback from missing env var to default",
+			with: v0.With{},
+			params: v0.InputMap{
+				"name": v0.InputParameter{
+					Description:    "Name with both default and missing default-from-env",
+					Default:        "fallback-value",
+					DefaultFromEnv: "NON_EXISTENT_ENV_VAR",
+				},
+			},
+			expected: v0.With{
+				"name": "fallback-value",
 			},
 		},
 	}

--- a/with_test.go
+++ b/with_test.go
@@ -746,6 +746,77 @@ func TestMergeWithAndParams(t *testing.T) {
 				"name": "fallback-value",
 			},
 		},
+		{
+			name: "nil with parameter creates new map",
+			with: nil,
+			params: v0.InputMap{
+				"name": v0.InputParameter{
+					Default: "default-value",
+				},
+			},
+			expected: v0.With{
+				"name": "default-value",
+			},
+		},
+		{
+			name: "nil with parameter with required input missing",
+			with: nil,
+			params: v0.InputMap{
+				"name": v0.InputParameter{
+					Required: &requiredTrue,
+				},
+			},
+			expectedError: "missing required input: \"name\"",
+		},
+		{
+			name: "nil with parameter with env var",
+			with: nil,
+			params: v0.InputMap{
+				"name": v0.InputParameter{
+					DefaultFromEnv: "TEST_ENV_VAR",
+				},
+			},
+			expected: v0.With{
+				"name": "env-value",
+			},
+		},
+		{
+			name: "validation with non-string value that cannot be cast to string",
+			with: v0.With{
+				"data": complex(1, 2), // complex numbers cannot be cast to string
+			},
+			params: v0.InputMap{
+				"data": v0.InputParameter{
+					Validate: "^test",
+				},
+			},
+			expectedError: "unable to cast (1+2i) of type complex128 to string",
+		},
+		{
+			name: "string casting error in type matching section",
+			with: v0.With{
+				"data": complex(1, 2), // complex numbers cannot be cast to string
+			},
+			params: v0.InputMap{
+				"data": v0.InputParameter{
+					Default: "string-default", // This will trigger string casting
+				},
+			},
+			expectedError: "unable to cast (1+2i) of type complex128 to string",
+		},
+		{
+			name: "nil with parameter requiring default assignment triggers map creation",
+			with: nil, // This ensures merged starts as nil
+			params: v0.InputMap{
+				"name": v0.InputParameter{
+					Default:  "test-value",
+					Required: &requiredFalse, // Ensure it's not required
+				},
+			},
+			expected: v0.With{
+				"name": "test-value",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
`default` and `default-from-env` were mutually exclusive properties. Upon usage this behavior is not actually desired.

Inputs value defaults now follow: `--with` flag or `with:` property then `default-from-env` then `default`.
