### PR TITLE
chore: update go to v1.25.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Go Version
       description: What version of Go are you using? (if building from source)
-      placeholder: "go version go1.24.3 linux/amd64"
+      placeholder: "go version go1.25.0 linux/amd64"
     validations:
       required: false
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ These foundational rules guide all performance and algorithmic decisions:
 ### High-Level Repository Information
 
 - **Size**: Medium-sized Go project (~106 files including tests and documentation)
-- **Language**: Go 1.24.3 (primary), YAML, Markdown, Shell scripts
+- **Language**: Go (current version in `go.mod`) (primary), YAML, Markdown, Shell scripts
 - **Framework**: Cobra CLI framework with Go modules dependency management
 - **Target**: Cross-platform static binaries (Linux, macOS, supports amd64/arm64) with `CGO_ENABLED=0`
 - **Status**: Early development - expect breaking changes
@@ -381,7 +381,7 @@ Maru2 maintains a **minimal dependency footprint** with carefully selected, well
 
 - `README.md` - Installation and basic usage
 - `Makefile` - Build commands and orchestration
-- `go.mod` - Dependencies (Go 1.24.3)
+- `go.mod` - Go dependencies and language version
 - `tasks.yaml` - Example workflow file
 - `maru2.schema.json` - Auto-generated schema
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defenseunicorns/maru2
 
-go 1.24.3
+go 1.25.0
 
 tool oras.land/oras/cmd/oras
 


### PR DESCRIPTION
Update to go v1.25.0, updates docs refs as well. CI requires no updates as it uses `go.mod` as source of truth.
