### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @Noxsios
+* @defenseunicorns/uds-cli
 
 /CODEOWNERS @jeff-mccoy @daveworth
 /LICENSE @jeff-mccoy @austenbryan


### PR DESCRIPTION
Updates codeowners to the `defenseunicorns/uds-cli` team vs just me.
