### PR TITLE
fix: base url

### DIFF
--- a/uses/fetcher_service.go
+++ b/uses/fetcher_service.go
@@ -137,13 +137,13 @@ func (s *FetcherService) createFetcher(uri *url.URL) (Fetcher, error) {
 
 		qualifiers := pURL.Qualifiers.Map()
 		tokenEnv := qualifiers[QualifierTokenFromEnv]
-		base := qualifiers[QualifierBaseURL]
+		baseURL := qualifiers[QualifierBaseURL]
 
 		switch pURL.Type {
 		case packageurl.TypeGithub:
-			fetcher, err = NewGitHubClient(s.client, base, tokenEnv)
+			fetcher, err = NewGitHubClient(s.client, baseURL, tokenEnv)
 		case packageurl.TypeGitlab:
-			fetcher, err = NewGitLabClient(s.client, base, tokenEnv)
+			fetcher, err = NewGitLabClient(s.client, baseURL, tokenEnv)
 		default:
 			return nil, fmt.Errorf("unsupported package type: %q", pURL.Type)
 		}

--- a/uses/fetcher_service_test.go
+++ b/uses/fetcher_service_test.go
@@ -116,12 +116,12 @@ func TestFetcherService(t *testing.T) {
 		},
 		{
 			name:        "github base url is invalid",
-			uri:         "pkg:github/noxsios/vai?base=:%20invalid",
+			uri:         "pkg:github/noxsios/vai?base-url=:%20invalid",
 			expectedErr: "invalid base URL: parse \": invalid\": missing protocol scheme",
 		},
 		{
 			name:        "gitlab base url is invalid",
-			uri:         "pkg:gitlab/noxsios/vai?base=:%20invalid",
+			uri:         "pkg:gitlab/noxsios/vai?base-url=:%20invalid",
 			expectedErr: "parse \": invalid/\": missing protocol scheme",
 		},
 		{
@@ -248,7 +248,7 @@ func TestFetcherService(t *testing.T) {
 		},
 		{
 			name:         "get github fetcher with base url qualifier",
-			uri:          "pkg:github/defenseunicorns/maru2?base=https://github.example.com",
+			uri:          "pkg:github/defenseunicorns/maru2?base-url=https://github.example.com",
 			expectedType: &GitHubClient{},
 		},
 		{
@@ -258,7 +258,7 @@ func TestFetcherService(t *testing.T) {
 		},
 		{
 			name:         "get github fetcher with both qualifiers",
-			uri:          "pkg:github/defenseunicorns/maru2?base=https://github.example.com&token-from-env=GITHUB_TOKEN",
+			uri:          "pkg:github/defenseunicorns/maru2?base-url=https://github.example.com&token-from-env=GITHUB_TOKEN",
 			expectedType: &GitHubClient{},
 		},
 		{

--- a/uses/gitlab_test.go
+++ b/uses/gitlab_test.go
@@ -5,7 +5,6 @@ package uses
 
 import (
 	"io"
-	"net/url"
 	"testing"
 
 	"github.com/charmbracelet/log"
@@ -29,21 +28,27 @@ func TestGitLabFetcher(t *testing.T) {
 		assert.Nil(t, rc)
 		require.EqualError(t, err, `uri is nil`)
 
-		u, err := url.Parse("file:foo.yaml")
+		u, err := ResolveRelative(nil, "file:foo.yaml", nil)
 		require.NoError(t, err)
 
 		rc, err = client.Fetch(ctx, u)
 		require.EqualError(t, err, `purl scheme is not "pkg": "file"`)
 		assert.Nil(t, rc)
 
-		u, err = url.Parse("pkg:github/foo.yaml")
+		u, err = ResolveRelative(nil, "pkg:github/foo.yaml", nil)
 		require.NoError(t, err)
 
 		rc, err = client.Fetch(ctx, u)
 		require.EqualError(t, err, `purl type is not "gitlab": "github"`)
 		assert.Nil(t, rc)
 
-		u, err = url.Parse("pkg:gitlab/noxsios/vai@main?task=hello-world#vai.yaml")
+		u, err = ResolveRelative(nil, "pkg:gitlab/noxsios/vai@main?task=hello-world#vai.yaml", nil)
+		require.NoError(t, err)
+
+		rc, err = client.Fetch(ctx, u)
+		require.NoError(t, err)
+
+		u, err = ResolveRelative(nil, "pkg:gitlab/noxsios/vai@foo%2Fbar?task=hello-world#vai.yaml", nil)
 		require.NoError(t, err)
 
 		rc, err = client.Fetch(ctx, u)
@@ -79,9 +84,14 @@ hello-world:
 		client, err := NewGitLabClient(nil, "", "")
 		require.NoError(t, err)
 		assert.NotNil(t, client)
-		baseURL := "https://gitlab.example.com"
+
+		assert.Equal(t, "https://localhost:555/api/v4/", client.client.BaseURL().String())
+
+		baseURL := "https://gitlab.example.com/"
 		client, err = NewGitLabClient(nil, baseURL, "")
 		require.NoError(t, err)
 		assert.NotNil(t, client)
+
+		assert.Equal(t, baseURL+"api/v4/", client.client.BaseURL().String())
 	})
 }

--- a/uses/gitlab_test.go
+++ b/uses/gitlab_test.go
@@ -48,13 +48,22 @@ func TestGitLabFetcher(t *testing.T) {
 		rc, err = client.Fetch(ctx, u)
 		require.NoError(t, err)
 
+		b, err := io.ReadAll(rc)
+		require.NoError(t, err)
+
+		assert.Equal(t, `# yaml-language-server: $schema=vai.schema.json
+
+hello-world:
+  - run: echo "Hello, World!"
+`, string(b))
+
 		u, err = ResolveRelative(nil, "pkg:gitlab/noxsios/vai@foo%2Fbar?task=hello-world#vai.yaml", nil)
 		require.NoError(t, err)
 
 		rc, err = client.Fetch(ctx, u)
 		require.NoError(t, err)
 
-		b, err := io.ReadAll(rc)
+		b, err = io.ReadAll(rc)
 		require.NoError(t, err)
 
 		assert.Equal(t, `# yaml-language-server: $schema=vai.schema.json

--- a/uses/gitlab_test.go
+++ b/uses/gitlab_test.go
@@ -94,7 +94,7 @@ hello-world:
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 
-		assert.Equal(t, "https://localhost:555/api/v4/", client.client.BaseURL().String())
+		assert.Equal(t, "https://gitlab.com/api/v4/", client.client.BaseURL().String())
 
 		baseURL := "https://gitlab.example.com/"
 		client, err = NewGitLabClient(nil, baseURL, "")

--- a/uses/url_resolver_test.go
+++ b/uses/url_resolver_test.go
@@ -259,7 +259,7 @@ func TestResolveURL(t *testing.T) {
 					BaseURL: "https://github.com/",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=https%3A%2F%2Fgithub.com%2F#dir/bar.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=https%3A%2F%2Fgithub.com%2F#dir/bar.yaml",
 		},
 		{
 			name: "pkg -> file with alias resolution",
@@ -271,7 +271,7 @@ func TestResolveURL(t *testing.T) {
 					BaseURL: "https://github.com",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=https%3A%2F%2Fgithub.com#dir/bar.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=https%3A%2F%2Fgithub.com#dir/bar.yaml",
 		},
 		{
 			name: "pkg -> file with task param and alias resolution",
@@ -284,7 +284,7 @@ func TestResolveURL(t *testing.T) {
 					TokenFromEnv: "GITHUB_TOKEN",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=https%3A%2F%2Fgithub.com&task=baz&token-from-env=GITHUB_TOKEN#dir/bar.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=https%3A%2F%2Fgithub.com&task=baz&token-from-env=GITHUB_TOKEN#dir/bar.yaml",
 		},
 		{
 			name:        "pkg -> file with invalid package URL",
@@ -410,7 +410,7 @@ func TestResolveURL(t *testing.T) {
 					TokenFromEnv: "CUSTOM_TOKEN",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=https%3A%2F%2Fcustom.github.com&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=https%3A%2F%2Fcustom.github.com&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
 		},
 		{
 			name: "pkg alias resolution preserves existing qualifiers",
@@ -423,12 +423,12 @@ func TestResolveURL(t *testing.T) {
 					TokenFromEnv: "CUSTOM_TOKEN",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=https%3A%2F%2Fcustom.github.com&existing=value&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=https%3A%2F%2Fcustom.github.com&existing=value&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
 		},
 		{
 			name: "pkg alias resolution does not override existing qualifiers",
 			prev: "file:foo.yaml",
-			uri:  "pkg:custom/owner/repo@v1.0.0?base=override#dir/foo.yaml",
+			uri:  "pkg:custom/owner/repo@v1.0.0?base-url=override#dir/foo.yaml",
 			aliases: v1.AliasMap{
 				"custom": {
 					Type:         "github",
@@ -436,7 +436,7 @@ func TestResolveURL(t *testing.T) {
 					TokenFromEnv: "CUSTOM_TOKEN",
 				},
 			},
-			next: "pkg:github/owner/repo@v1.0.0?base=override&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
+			next: "pkg:github/owner/repo@v1.0.0?base-url=override&token-from-env=CUSTOM_TOKEN#dir/foo.yaml",
 		},
 		{
 			name: "oci -> https",

--- a/uses/uses.go
+++ b/uses/uses.go
@@ -20,7 +20,7 @@ const DefaultVersion = "main"
 const QualifierTokenFromEnv = "token-from-env"
 
 // QualifierBaseURL is the qualifier for the base URL to use when fetching a package
-const QualifierBaseURL = "base"
+const QualifierBaseURL = "base-url"
 
 // QualifierTask is the qualifier for the task to use when fetching a package
 const QualifierTask = "task"


### PR DESCRIPTION
When the config key was changed from `base` to `base-url`, I forgot to update the pURL qualifier from `base` to `base-url`. This PR also adds a unit test around the GitLab base URL to ensure it is properly set when specified.