### PR TITLE
ci: wire up brew

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -18,8 +18,7 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,8 +37,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -47,6 +46,15 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
+      - name: Get Brew tap repo token
+        id: brew-tap-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_SECRET }}
+          owner: defenseunicorns
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
@@ -54,3 +62,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,42 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
+brews:
+  - name: "{{ .Env.BREW_NAME }}"
+    repository:
+      owner: defenseunicorns
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
+
+    commit_msg_template: "build(release): upgrade {{ .ProjectName }} to {{ .Tag }}"
+    homepage: "https://github.com/defenseunicorns/maru2"
+    description: "A simple task runner"
+
+  # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
+  #       install versioned releases that has a `v` character before the version number.
+  - name: "maru2@{{ .Version }}"
+    repository:
+      owner: defenseunicorns
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
+    commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
+    homepage: "https://github.com/defenseunicorns/maru2"
+    description: "A simple task runner"
+
 changelog:
   disable: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,7 +54,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 brews:
-  - name: "{{ .Env.BREW_NAME }}"
+  - name: maru2
+    ids: [maru2]
     repository:
       owner: defenseunicorns
       name: homebrew-tap
@@ -74,6 +75,7 @@ brews:
   # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
   #       install versioned releases that has a `v` character before the version number.
   - name: "maru2@{{ .Version }}"
+    ids: [maru2]
     repository:
       owner: defenseunicorns
       name: homebrew-tap
@@ -88,6 +90,43 @@ brews:
     commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "A simple task runner"
+
+  - name: maru2-publish
+    ids: [maru2-publish]
+    repository:
+      owner: defenseunicorns
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
+
+    commit_msg_template: "build(release): upgrade {{ .ProjectName }} to {{ .Tag }}"
+    homepage: "https://github.com/defenseunicorns/maru2"
+    description: "Pack a maru2 workflow into an OCI artifact and publish"
+
+  # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
+  #       install versioned releases that has a `v` character before the version number.
+  - name: "maru2-publish@{{ .Version }}"
+    ids: [maru2-publish]
+    repository:
+      owner: defenseunicorns
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
+    commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
+    homepage: "https://github.com/defenseunicorns/maru2"
+    description: "Pack a maru2 workflow into an OCI artifact and publish"
 
 changelog:
   disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,10 +67,11 @@ brews:
           branch: main
           owner: defenseunicorns
           name: homebrew-tap
-
     commit_msg_template: "build(release): upgrade {{ .ProjectName }} to {{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "A simple task runner"
+    post_install: |
+      generate_completions_from_executable(bin/"maru2", "completion")
 
   # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
   #       install versioned releases that has a `v` character before the version number.
@@ -90,6 +91,8 @@ brews:
     commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "A simple task runner"
+    post_install: |
+      generate_completions_from_executable(bin/"maru2@{{ .Version }}", "completion")
 
   - name: maru2-publish
     ids: [maru2-publish]
@@ -104,10 +107,11 @@ brews:
           branch: main
           owner: defenseunicorns
           name: homebrew-tap
-
     commit_msg_template: "build(release): upgrade {{ .ProjectName }}-publish to {{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "Pack a maru2 workflow into an OCI artifact and publish"
+    post_install: |
+      generate_completions_from_executable(bin/"maru2-publish", "completion")
 
   # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
   #       install versioned releases that has a `v` character before the version number.
@@ -127,6 +131,8 @@ brews:
     commit_msg_template: "build(release): {{ .ProjectName }}-publish@{{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "Pack a maru2 workflow into an OCI artifact and publish"
+    post_install: |
+      generate_completions_from_executable(bin/"maru2-publish@{{ .Version }}", "completions")
 
 changelog:
   disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,7 +55,6 @@ archives:
 
 brews:
   - name: maru2
-    ids: [maru2]
     repository:
       owner: defenseunicorns
       name: homebrew-tap
@@ -72,11 +71,11 @@ brews:
     description: "A simple task runner"
     post_install: |
       generate_completions_from_executable(bin/"maru2", "completion")
+      generate_completions_from_executable(bin/"maru2-publish", "completion")
 
   # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
   #       install versioned releases that has a `v` character before the version number.
   - name: "maru2@{{ .Version }}"
-    ids: [maru2]
     repository:
       owner: defenseunicorns
       name: homebrew-tap
@@ -93,46 +92,7 @@ brews:
     description: "A simple task runner"
     post_install: |
       generate_completions_from_executable(bin/"maru2@{{ .Version }}", "completion")
-
-  - name: maru2-publish
-    ids: [maru2-publish]
-    repository:
-      owner: defenseunicorns
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-      branch: "{{ .ProjectName }}-{{ .Tag }}"
-      pull_request:
-        enabled: true
-        base:
-          branch: main
-          owner: defenseunicorns
-          name: homebrew-tap
-    commit_msg_template: "build(release): upgrade {{ .ProjectName }}-publish to {{ .Tag }}"
-    homepage: "https://github.com/defenseunicorns/maru2"
-    description: "Pack a maru2 workflow into an OCI artifact and publish"
-    post_install: |
-      generate_completions_from_executable(bin/"maru2-publish", "completion")
-
-  # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
-  #       install versioned releases that has a `v` character before the version number.
-  - name: "maru2-publish@{{ .Version }}"
-    ids: [maru2-publish]
-    repository:
-      owner: defenseunicorns
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-      branch: "{{ .ProjectName }}-{{ .Tag }}"
-      pull_request:
-        enabled: true
-        base:
-          branch: main
-          owner: defenseunicorns
-          name: homebrew-tap
-    commit_msg_template: "build(release): {{ .ProjectName }}-publish@{{ .Tag }}"
-    homepage: "https://github.com/defenseunicorns/maru2"
-    description: "Pack a maru2 workflow into an OCI artifact and publish"
-    post_install: |
-      generate_completions_from_executable(bin/"maru2-publish@{{ .Version }}", "completions")
+      generate_completions_from_executable(bin/"maru2-publish@{{ .Version }}", "completion")
 
 changelog:
   disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,7 +105,7 @@ brews:
           owner: defenseunicorns
           name: homebrew-tap
 
-    commit_msg_template: "build(release): upgrade {{ .ProjectName }} to {{ .Tag }}"
+    commit_msg_template: "build(release): upgrade {{ .ProjectName }}-publish to {{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "Pack a maru2 workflow into an OCI artifact and publish"
 
@@ -124,7 +124,7 @@ brews:
           branch: main
           owner: defenseunicorns
           name: homebrew-tap
-    commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
+    commit_msg_template: "build(release): {{ .ProjectName }}-publish@{{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/maru2"
     description: "Pack a maru2 workflow into an OCI artifact and publish"
 


### PR DESCRIPTION
Wires up maru2 and maru2-publish to be also released to the `defenseunicorns/homebrew-tap` repo.
