### PR TITLE
feat: config env var

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,9 +51,19 @@ func NewRootCmd() *cobra.Command {
 
 	// closure initializer
 	loadConfig := func(cmd *cobra.Command) error {
-		switch cmd.Flags().Changed("config") {
-		case true:
+		switch {
+		case cmd.Flags().Changed("config"):
 			f, err := os.Open(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to open config file: %w", err)
+			}
+			defer f.Close()
+			cfg, err = configv0.LoadConfig(f)
+			if err != nil {
+				return fmt.Errorf("failed to load config file: %w", err)
+			}
+		case os.Getenv("MARU2_CONFIG") != "":
+			f, err := os.Open(os.Getenv("MARU2_CONFIG"))
 			if err != nil {
 				return fmt.Errorf("failed to open config file: %w", err)
 			}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,14 +147,16 @@ This visual indicator helps you identify dynamic parts of your workflow that dep
 
 ## System config
 
-Maru2 has a system [configuration file](./config.md) that affects default flag behavior. When the `--config` flag is set, it takes precedence over the default config.
+Maru2 has a system [configuration file](./config.md) that affects default flag behavior. Configuration loading follows this priority order:
+
+1. `--config` flag (highest priority)
+2. `MARU2_CONFIG` environment variable
+3. `~/.maru2/config.yaml` (default)
 
 ```sh
-$ cat custom.yaml
-schema-version: v0
-fetch-policy: always
-
-$ maru2 --config custom.yaml ...
+$ maru2 --config custom.yaml        # flag
+$ MARU2_CONFIG=custom.yaml maru2    # env var
+$ maru2                             # default
 ```
 
 ## Task Execution

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,17 +4,21 @@ This document describes how to configure Maru2 using the global configuration fi
 
 ## Configuration File Location
 
-By default, Maru2 looks for the configuration file at:
+Maru2 loads configuration in priority order:
 
-```text
-~/.maru2/config.yaml
+1. `--config` flag (highest priority)
+2. `MARU2_CONFIG` environment variable
+3. `~/.maru2/config.yaml` (default)
+
+```sh
+maru2 --config custom.yaml        # flag
+MARU2_CONFIG=custom.yaml maru2    # env var
+maru2                             # default
 ```
-
-and can also be configured via the [`--config`](./cli.md#config) flag.
 
 ## Creating a New Configuration
 
-To create a new configuration:
+To create a new global configuration:
 
 1. Create the directory if it doesn't exist:
 

--- a/testdata/config-env-var.txtar
+++ b/testdata/config-env-var.txtar
@@ -1,0 +1,41 @@
+env MARU2_CONFIG=custom-config.yaml
+exec maru2 --list
+! stderr 'failed to load config file'
+
+env MARU2_CONFIG=custom-config.yaml
+exec maru2 --config flag-config.yaml --list
+! stderr 'failed to load config file'
+
+env MARU2_CONFIG=nonexistent.yaml
+! exec maru2 --list
+stderr 'failed to open config file'
+
+env MARU2_CONFIG=malformed-config.yaml
+! exec maru2 --list
+stderr 'failed to load config file'
+
+env MARU2_CONFIG=malformed-config.yaml
+! exec maru2 --config nonexistent-flag.yaml --list
+stderr 'failed to open config file'
+! stderr 'failed to load config file'
+
+env MARU2_CONFIG=
+exec maru2 --list
+! stderr 'failed to load config file'
+
+-- custom-config.yaml --
+schema-version: v0
+fetch-policy: if-not-present
+
+-- flag-config.yaml --
+schema-version: v0
+fetch-policy: always
+
+-- malformed-config.yaml --
+schema-version: v0
+invalid: "unclosed string
+
+-- tasks.yaml --
+schema-version: v0
+tasks:
+  echo: [run: echo "Hello World!"]


### PR DESCRIPTION
Adds `MARU2_CONFIG` as a option in addition to the `--config` flag and default `~/.maru2/config.yaml` options for providing the CLI config.