### PR TITLE
refactor: more runtime options

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@ Fixes #
 
 Relates to #
 
-[ ] I have read the [Contributor Guide](https://github.com/defenseunicorns/maru2/blob/main/.github/CONTRIBUTING.md) and [Developer Guide](https://github.com/defenseunicorns/maru2/blob/main/docs/developing.md).
+- [ ] I have read the [Contributor Guide](https://github.com/defenseunicorns/maru2/blob/main/.github/CONTRIBUTING.md) and [Developer Guide](https://github.com/defenseunicorns/maru2/blob/main/docs/developing.md).

--- a/builtins/basic_test.go
+++ b/builtins/basic_test.go
@@ -5,9 +5,9 @@ package builtins
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -210,7 +210,7 @@ func TestBuiltinFetch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := log.WithContext(t.Context(), log.New(os.Stderr))
+			ctx := log.WithContext(t.Context(), log.New(io.Discard))
 
 			result, err := tc.fetch.Execute(ctx)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -281,7 +282,7 @@ maru2 -f "pkg:github/defenseunicorns/maru2@main#testdata/simple.yaml" echo -w me
 			}
 
 			if explain {
-				if IsTerminal(int(os.Stdout.Fd())) {
+				if IsTerminal(cmd.OutOrStdout()) {
 					renderer, err := glamour.NewTermRenderer(glamour.WithStyles(styles.TokyoNightStyleConfig), glamour.WithWordWrap(100))
 					if err != nil {
 						return err
@@ -483,6 +484,10 @@ func ParseExitCode(err error) int {
 }
 
 // IsTerminal is a slim wrapper around term.IsTerminal, exported just so that E2E tests can mock
-var IsTerminal = func(fd int) bool {
-	return term.IsTerminal(fd)
+var IsTerminal = func(wr io.Writer) bool {
+	if f, ok := wr.(*os.File); ok && f != nil {
+		return term.IsTerminal(int(f.Fd()))
+	}
+
+	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -343,8 +343,11 @@ maru2 -f "pkg:github/defenseunicorns/maru2@main#testdata/simple.yaml" echo -w me
 			}
 
 			opts := maru2.RuntimeOptions{
-				Dry: dry,
-				Env: os.Environ(),
+				Dry:    dry,
+				Env:    os.Environ(),
+				Stdout: cmd.OutOrStdout(),
+				Stderr: cmd.OutOrStderr(),
+				Stdin:  cmd.InOrStdin(),
 			}
 
 			for _, call := range args {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,7 @@ package cmd_test
 
 import (
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +31,20 @@ func TestE2E(t *testing.T) {
 		RequireUniqueNames: true,
 		UpdateScripts:      os.Getenv("UPDATE_SCRIPTS") == "true",
 	})
+}
+
+func TestIsTerminal(t *testing.T) {
+	assert.True(t, cmd.IsTerminal(os.Stdout))
+	assert.True(t, cmd.IsTerminal(os.Stderr))
+	tmp := t.TempDir()
+	f, err := os.CreateTemp(tmp, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+	assert.False(t, cmd.IsTerminal(f))
+	assert.False(t, cmd.IsTerminal(nil))
+	assert.False(t, cmd.IsTerminal(&strings.Builder{}))
 }
 
 func TestExplainRedirect(t *testing.T) {
@@ -90,7 +105,7 @@ tasks:
 	t.Cleanup(func() {
 		cmd.IsTerminal = curr
 	})
-	cmd.IsTerminal = func(int) bool {
+	cmd.IsTerminal = func(io.Writer) bool {
 		return true
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -33,9 +33,8 @@ func TestE2E(t *testing.T) {
 	})
 }
 
+// this does not test for "success" cases due to go test runner hijacking os.Stdout and os.Stderr
 func TestIsTerminal(t *testing.T) {
-	assert.True(t, cmd.IsTerminal(os.Stdout))
-	assert.True(t, cmd.IsTerminal(os.Stderr))
 	tmp := t.TempDir()
 	f, err := os.CreateTemp(tmp, "")
 	require.NoError(t, err)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -260,6 +260,25 @@ $ MARU2_CONFIG=custom.yaml maru2    # env var
 $ maru2                             # default
 ```
 
+## Environment variables
+
+### MARU2_CONFIG
+
+Overrides the default path to the maru2 config file. See above and/or [config.md](config.md).
+
+### TEMPDIR
+
+Maru2 uses temporary files to capture the outputs of tasks. By default, these temporary files are created in the OS-specific temporary directory. You can override this location by setting the `TEMPDIR` environment variable.
+
+```sh
+mkdir -p /path/to/tmp
+TEMPDIR=/path/to/tmp maru2 my-task
+```
+
+If specified, users will need to ensure this directory exists with the proper permissions before Maru2 execution.
+
+Maru2 does not handle cleanup of this directory either.
+
 ## Task execution
 
 ### The default task

--- a/publish.go
+++ b/publish.go
@@ -38,11 +38,16 @@ func Publish(ctx context.Context, dst *remote.Repository, entrypoints []string) 
 		return fmt.Errorf("need at least one entrypoint")
 	}
 
+	// using os.CreateTemp w/ an empty string as the first argument
+	// leverages the TMPDIR environment variable, otherwise OS specific defaults
+	// see `go doc os.TempDir`
 	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
 
+	// leverages the PWD environment variable, otherwise OS specific defaults
+	// see `go doc os.Getwd`
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/run.go
+++ b/run.go
@@ -238,7 +238,7 @@ func handleRunStep(
 		return nil, nil
 	}
 
-	// using os.CreateTempe w/ an empty string as the first argument
+	// using os.CreateTemp w/ an empty string as the first argument
 	// leverages the TMPDIR environment variable, otherwise OS specific defaults
 	// see `go doc os.TempDir`
 	outFile, err := os.CreateTemp("", "maru2-output-*")

--- a/run.go
+++ b/run.go
@@ -238,6 +238,9 @@ func handleRunStep(
 		return nil, nil
 	}
 
+	// using os.CreateTempe w/ an empty string as the first argument
+	// leverages the TMPDIR environment variable, otherwise OS specific defaults
+	// see `go doc os.TempDir`
 	outFile, err := os.CreateTemp("", "maru2-output-*")
 	if err != nil {
 		return nil, err

--- a/run.go
+++ b/run.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net/url"
 	"os"
@@ -41,6 +42,12 @@ type RuntimeOptions struct {
 	Dry bool
 	// Whether this execution is already inside a collapsible section in CI, disables nested collapsible sections if true
 	Collapsed bool
+	// See `go doc exec.Cmd.Stdout`
+	Stdout io.Writer
+	// See `go doc exec.Cmd.Stderr`
+	Stderr io.Writer
+	// See `go doc exec.Cmd.Stdin`
+	Stdin io.Reader
 }
 
 /*
@@ -105,7 +112,7 @@ func Run(
 	start := time.Now()
 
 	if task.Collapse && !ro.Collapsed {
-		closeGroup := printGroup(os.Stdout, taskName, task.Description)
+		closeGroup := printGroup(ro.Stdout, taskName, task.Description)
 		defer closeGroup()
 		ro.Collapsed = true
 	}
@@ -269,9 +276,9 @@ func handleRunStep(
 	cmd := exec.CommandContext(ctx, shell, args...)
 	cmd.Env = env
 	cmd.Dir = filepath.Join(ro.WorkingDir, step.Dir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+	cmd.Stdout = ro.Stdout
+	cmd.Stderr = ro.Stderr
+	cmd.Stdin = ro.Stdin
 
 	if step.Mute {
 		cmd.Stdout = nil


### PR DESCRIPTION
Add stdout, stderr and stdin to runtime options so they can be better used in other functions.

- [x] I have read the [Contributor Guide](https://github.com/defenseunicorns/maru2/blob/main/.github/CONTRIBUTING.md) and [Developer Guide](https://github.com/defenseunicorns/maru2/blob/main/docs/developing.md).
